### PR TITLE
Update CLHEP and Geant4 versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,22 +48,26 @@ COPY provisioning/install-sw-scripts/clhep-* provisioning/install-sw-scripts/gea
 ENV \
     PATH="/opt/geant4/bin:/opt/clhep/bin:$PATH" \
     LD_LIBRARY_PATH="/opt/geant4/lib64:/opt/clhep/lib:$LD_LIBRARY_PATH" \
-    G4LEDATA="/opt/geant4/share/Geant4-9.6.4/data/G4EMLOW6.32" \
-    G4LEVELGAMMADATA="/opt/geant4/share/Geant4-9.6.4/data/PhotonEvaporation2.3" \
-    G4NEUTRONHPDATA="/opt/geant4/share/Geant4-9.6.4/data/G4NDL4.2" \
-    G4NEUTRONXSDATA="/opt/geant4/share/Geant4-9.6.4/data/G4NEUTRONXS1.2" \
-    G4PIIDATA="/opt/geant4/share/Geant4-9.6.4/data/G4PII1.3" \
-    G4RADIOACTIVEDATA="/opt/geant4/share/Geant4-9.6.4/data/RadioactiveDecay3.6" \
-    G4REALSURFACEDATA="/opt/geant4/share/Geant4-9.6.4/data/RealSurface1.0" \
-    G4SAIDXSDATA="/opt/geant4/share/Geant4-9.6.4/data/G4SAIDDATA1.1"
+    G4LEDATA="/opt/geant4/share/Geant4-10.4.2/data/G4EMLOW7.3" \
+    G4LEVELGAMMADATA="/opt/geant4/share/Geant4-10.4.2/data/PhotonEvaporation5.2" \
+    G4NEUTRONHPDATA="/opt/geant4/share/Geant4-10.4.2/data/G4NDL4.5" \
+    G4NEUTRONXSDATA="/opt/geant4/share/Geant4-10.4.2/data/G4NEUTRONXS1.4" \
+    G4PIIDATA="/opt/geant4/share/Geant4-10.4.2/data/G4PII1.3" \
+    G4RADIOACTIVEDATA="/opt/geant4/share/Geant4-10.4.2/data/RadioactiveDecay5.2" \
+    G4REALSURFACEDATA="/opt/geant4/share/Geant4-10.4.2/data/RealSurface2.1.1" \
+    G4SAIDXSDATA="/opt/geant4/share/Geant4-10.4.2/data/G4SAIDDATA1.1" \
+    G4ENSDFSTATEDATA="/opt/geant4/share/Geant4-10.4.2/data/G4ENSDFSTATE2.2" \
+    G4ABLADATA="/opt/geant4/share/Geant4-10.4.2/data/G4ABLA3.1" \
+    AllowForHeavyElements=1
+
 
 RUN true \
     && yum install -y \
         expat-devel xerces-c-devel zlib-devel \
         libXmu-devel libXi-devel \
         mesa-libGLU-devel motif-devel mesa-libGLw qt-devel \
-    && provisioning/install-sw.sh clhep 2.1.3.1 /opt/clhep \
-    && provisioning/install-sw.sh geant4 9.6.4 /opt/geant4
+    && provisioning/install-sw.sh clhep 2.3.4.4 /opt/clhep \
+    && provisioning/install-sw.sh geant4 10.4.2 /opt/geant4
 
 
 # Install CERN ROOT:

--- a/provisioning/install-sw-scripts/clhep-setup.sh
+++ b/provisioning/install-sw-scripts/clhep-setup.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2016: Oliver Schulz.
 
 
-DEFAULT_BUILD_OPTS=""
+DEFAULT_BUILD_OPTS="-std=c++11"
 
 
 pkg_install() {

--- a/provisioning/install-sw-scripts/geant4-setup.sh
+++ b/provisioning/install-sw-scripts/geant4-setup.sh
@@ -7,6 +7,7 @@ BASIC_BUILD_OPTS="\
 --fail-on-missing \
 --enable-shared \
 --enable-soversion \
+-DGEANT4_BUILD_CXXSTD=c++11 \
 "
 
 ADDITIONAL_BUILD_OPTS="\


### PR DESCRIPTION
Hey @oschulz, the GERDA software should be all ready for this update. Now MGDO's `master` should compile successfully (because of the newer CLHEP) and also the `g4.10` branch of MaGe (which will be soon merged into `master`). Next step would be updating things also in gerda-sw-all.

However, we shouldn't trash the current gerda-base image, why not creating a `g9.6` tag or so on the Docker Hub?

PS: I don't think the `-std=c++11` flags are really needed, I always put them just to be sure!

