### PR TITLE
Downgrade ROOT again to 6.06/08 (reverts f9bef27)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN true \
         libXdmcp libXtst libxkbfile libXScrnSaver libXss.so.1 \
         libjpeg-devel libpng-devel \
         mesa-libGLU-devel \
-    && provisioning/install-sw.sh root 6.14.04 /opt/root
+    && provisioning/install-sw.sh root 6.06.08 /opt/root
 
 
 # Install Jupyter:


### PR DESCRIPTION
Ciao, after some discussions we decided to stick to ROOT v6.06/08, for now. The issues I had compiling MaGe with that version disappeared with the latest version of the build system, somehow.

@oschulz could you please merge, docker-build and docker-push this?

CC @azsigmon